### PR TITLE
Enhance: add tests for in loop named gotest detection

### DIFF
--- a/lib/framework/golang/gotest.rs
+++ b/lib/framework/golang/gotest.rs
@@ -405,7 +405,7 @@ pub(in crate::framework::golang) mod golang_subtests {
           ))
         ]]"#;
         let query = Query::new(&Language::new(tree_sitter_go::LANGUAGE), QUERY_PATTERN).ok()?;
-        let subcase_name_index = query.capture_index_for_name("test.case.name.value")?;
+        let subcase_name_index = query.capture_index_for_name("test.case.field.value")?;
         let subcase_index = query.capture_index_for_name("test.case")?;
         let mut cursor = QueryCursor::new();
         let query_matches = cursor.matches(&query, node, content.as_bytes());

--- a/lib/framework/golang/gotest.rs
+++ b/lib/framework/golang/gotest.rs
@@ -156,10 +156,7 @@ pub(in crate::framework::golang) mod golang_subtests {
     use tree_sitter::{Language, Node, Query, QueryCursor};
 
     use crate::{
-        core::{
-            enums,
-            types::{CursorPosition, Runnable, Target},
-        },
+        core::types::{CursorPosition, Runnable, Target},
         treesitter::node::node_text,
     };
 

--- a/lib/framework/golang/gotest_test.rs
+++ b/lib/framework/golang/gotest_test.rs
@@ -168,6 +168,7 @@ mod test {
         #[case] expected_num_of_tests: usize,
         #[case] expected_test_names: Vec<&str>,
     ) {
+        // ARRANGE
         let content = r#"
         package golang
         import (
@@ -226,10 +227,11 @@ mod test {
         assert_eq!(parent_runnable.name, "TestInLoopWithNamedSubtest");
 
         walker.reset(node);
-        // act
+
+        // ACT
         let res = get_sub_tests(Some(node), Some(parent_runnable), &target);
 
-        // assert
+        // ASSERT
         assert_that!(res.is_some(), eq(true));
         let res = res.unwrap();
         assert_that!(res.len(), eq(expected_num_of_tests));

--- a/lib/framework/golang/gotest_test.rs
+++ b/lib/framework/golang/gotest_test.rs
@@ -158,8 +158,10 @@ mod test {
     #[rstest]
     #[case(enums::Search::InFile, types::CursorPosition::new(19, 3), 2, vec!["TestInLoopWithNamedSubtest/base case", "TestInLoopWithNamedSubtest/case 1"])]
     #[case(enums::Search::Nearest, types::CursorPosition::new(19, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
-    #[case(enums::Search::InFile, types::CursorPosition::new(20, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
-    #[case(enums::Search::InFile, types::CursorPosition::new(24, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(20, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(24, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(25, 3), 1, vec!["TestInLoopWithNamedSubtest/case 1"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(30, 3), 1, vec!["TestInLoopWithNamedSubtest/case 1"])]
     fn get_in_loop_with_named_subtest(
         #[case] search: enums::Search,
         #[case] position: types::CursorPosition,

--- a/lib/framework/golang/gotest_test.rs
+++ b/lib/framework/golang/gotest_test.rs
@@ -153,4 +153,87 @@ mod test {
         // assert
         assert_that!(res.is_some(), eq(false));
     }
+
+    #[gtest]
+    #[rstest]
+    #[case(enums::Search::InFile, types::CursorPosition::new(19, 3), 2, vec!["TestInLoopWithNamedSubtest/base case", "TestInLoopWithNamedSubtest/case 1"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(19, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    #[case(enums::Search::InFile, types::CursorPosition::new(20, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    #[case(enums::Search::InFile, types::CursorPosition::new(24, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    fn get_in_loop_with_named_subtest(
+        #[case] search: enums::Search,
+        #[case] position: types::CursorPosition,
+        #[case] expected_num_of_tests: usize,
+        #[case] expected_test_names: Vec<&str>,
+    ) {
+        let content = r#"
+        package golang
+        import (
+          "testing"
+
+          "github.com/stretchr/testify/assert"
+        )
+
+        func sample_add(a, b int) int {
+          return a + b
+        }
+
+        func TestInLoopWithNamedSubtest(t *testing.T) {
+          for _, tt := range []struct {
+            description string
+            a           int
+            b           int
+            expected    int
+          }{
+            {
+              description: "base case",
+              a:           0,
+              b:           3,
+              expected:    3,
+            },
+            {
+              description: "case 1",
+              a:           1,
+              b:           3,
+              expected:    4,
+            },
+          } {
+            t.Run(tt.description, func(t *testing.T) {
+              actual := sample_add(tt.a, tt.b)
+              assert.Equal(t, tt.expected, actual)
+            })
+          }
+        }
+        "#;
+
+        let buffer = Buffer::new(content, "run_test.go".to_string(), position);
+        let mut target = Target::new(enums::ToolCategory::TestRunner, buffer);
+        target.override_search_strategy(search);
+
+        let tree = common::utils::parse_tree(content);
+        assert_that!(tree, ok(anything()));
+        let tree = tree.unwrap();
+        let mut walker = tree.walk();
+
+        walker.goto_first_child_for_point(position.to_point());
+
+        let node = walker.node();
+        let parent_runnable = get_parent_test(Some(node), &target);
+        assert_that!(parent_runnable.is_some(), eq(true));
+        let parent_runnable = parent_runnable.unwrap();
+        assert_eq!(parent_runnable.name, "TestInLoopWithNamedSubtest");
+
+        walker.reset(node);
+        // act
+        let res = get_sub_tests(Some(node), Some(parent_runnable), &target);
+
+        // assert
+        assert_that!(res.is_some(), eq(true));
+        let res = res.unwrap();
+        assert_that!(res.len(), eq(expected_num_of_tests));
+        for ts in expected_test_names {
+            let runnable = res.iter().find(|&x| x.name == ts);
+            assert_that!(runnable.is_some(), eq(true));
+        }
+    }
 }


### PR DESCRIPTION
## Related Issue  
<!-- Attached the related issue -->

N/A
### Additional Context

<!-- (Optional) add additional context about pull-request about. -->

Being able to detect go tests where the tests are in this format

```go
func TestInLoopWithNamedSubtest(t *testing.T) {
  for _, tt := range []struct {
    description string
    a           int
    b           int
    expected    int
  }{
    {
      description: "base case",
      a:           0,
      b:           3,
      expected:    3,
    },
    {
      description: "case 1",
      a:           1,
      b:           3,
      expected:    4,
    },
  } {
    t.Run(tt.description, func(t *testing.T) {
      actual := sample_add(tt.a, tt.b)
      assert.Equal(t, tt.expected, actual)
    })
  }
}

```

### How is it implemented

<!-- How is this change implemented -->

### Check the related fields

- [ ] Documentation <!-- Updates the documentation and related to this repository -->
- [ ] Feature <!-- Adds a net new capability -->
- [x] Enhancement <!-- updates an existing feature and adds to it -->
- [x] Test <!-- updates or adds new tests -->
- [ ] Chore
<!--
updates the way this repository is run
- ci
- issue templates
- license
- deployment
- release
-->
