### PR TITLE
enhance: enable parsing and locating tests in a loop

### DIFF
--- a/lib/framework/golang/gotest_test.rs
+++ b/lib/framework/golang/gotest_test.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod test {
-
     use crate::core::enums;
     use crate::framework::golang::gotest::get_parent_test;
     use crate::framework::golang::gotest::golang_subtests::get_sub_tests;
@@ -10,6 +9,7 @@ mod test {
     };
     use googletest::assert_that;
     use googletest::prelude::*;
+
     use rstest::rstest;
 
     #[test]
@@ -27,6 +27,7 @@ mod test {
             "sample_test.go".to_string(),
             types::CursorPosition::new(10, 3),
         );
+
         let target = Target::new(crate::core::enums::ToolCategory::TestRunner, buffer);
         let tree = common::utils::parse_tree(content);
         assert!(tree.is_ok());
@@ -162,7 +163,94 @@ mod test {
     #[case(enums::Search::Nearest, types::CursorPosition::new(24, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
     #[case(enums::Search::Nearest, types::CursorPosition::new(25, 3), 1, vec!["TestInLoopWithNamedSubtest/case 1"])]
     #[case(enums::Search::Nearest, types::CursorPosition::new(30, 3), 1, vec!["TestInLoopWithNamedSubtest/case 1"])]
-    fn get_in_loop_with_named_subtest(
+    fn get_in_loop_with_unnamed_subtests(
+        #[case] search: enums::Search,
+        #[case] position: types::CursorPosition,
+        #[case] expected_num_of_tests: usize,
+        #[case] expected_test_names: Vec<&str>,
+    ) {
+        // ARRANGE
+        let content = r#"
+        package golang
+        import (
+          "testing"
+
+          "github.com/stretchr/testify/assert"
+        )
+
+        func sample_add(a, b int) int {
+          return a + b
+        }
+
+        func TestInLoopWithNamedSubtest(t *testing.T) {
+          for _, tt := range []struct {
+            description string
+            a           int
+            b           int
+            expected    int
+          }{
+            {
+              "base case",
+              0,
+              3,
+              3,
+            },
+            {
+              "case 1",
+              1,
+              3,
+              4,
+            },
+          } {
+            t.Run(tt.description, func(t *testing.T) {
+              actual := sample_add(tt.a, tt.b)
+              assert.Equal(t, tt.expected, actual)
+            })
+          }
+        }
+        "#;
+
+        let buffer = Buffer::new(content, "run_test.go".to_string(), position);
+        let mut target = Target::new(enums::ToolCategory::TestRunner, buffer);
+        target.override_search_strategy(search);
+
+        let tree = common::utils::parse_tree(content);
+        assert_that!(tree, ok(anything()));
+        let tree = tree.unwrap();
+        let mut walker = tree.walk();
+
+        walker.goto_first_child_for_point(position.to_point());
+
+        let node = walker.node();
+        let parent_runnable = get_parent_test(Some(node), &target);
+        assert_that!(parent_runnable.is_some(), eq(true));
+        let parent_runnable = parent_runnable.unwrap();
+        assert_eq!(parent_runnable.name, "TestInLoopWithNamedSubtest");
+
+        walker.reset(node);
+
+        // ACT
+        let res = get_sub_tests(Some(node), Some(parent_runnable), &target);
+
+        // ASSERT
+        assert_that!(res.is_some(), eq(true));
+        let res = res.unwrap();
+        assert_that!(res.len(), eq(expected_num_of_tests));
+        for ts in expected_test_names {
+            let runnable = res.iter().find(|&x| x.name == ts);
+            assert_that!(runnable.is_some(), eq(true));
+        }
+    }
+
+    #[gtest]
+    #[rstest]
+    #[case(enums::Search::InFile, types::CursorPosition::new(19, 3), 2, vec!["TestInLoopWithNamedSubtest/base case", "TestInLoopWithNamedSubtest/case 1"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(19, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(20, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(24, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(25, 3), 1, vec!["TestInLoopWithNamedSubtest/case 1"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(30, 3), 1, vec!["TestInLoopWithNamedSubtest/case 1"])]
+    fn get_in_loop_with_named_subtests(
         #[case] search: enums::Search,
         #[case] position: types::CursorPosition,
         #[case] expected_num_of_tests: usize,


### PR DESCRIPTION

## Related Issue  
<!-- Attached the related issue -->

n/a

### Additional Context

<!-- (Optional) add additional context about pull-request about. -->

test case variable is defined in loop but the case name field is not explicitly set

Sample:

```go
        func TestInLoopWithNamedSubtest(t *testing.T) {
          for _, tt := range []struct {
            description string
            a           int
            b           int
            expected    int
          }{
            {
              description: "base case",
              a:           0,
              b:           3,
              expected:    3,
            },
            {
              description: "case 1",
              a:           1,
              b:           3,
              expected:    4,
            },
          } {
            t.Run(tt.description, func(t *testing.T) {
              actual := sample_add(tt.a, tt.b)
              assert.Equal(t, tt.expected, actual)
            })
          }
        }

```
### How is it implemented

<!-- How is this change implemented -->

### Check the related fields

- [ ] Documentation <!-- Updates the documentation and related to this repository -->
- [ ] Feature <!-- Adds a net new capability -->
- [x] Enhancement <!-- updates an existing feature and adds to it -->
- [x] Test <!-- updates or adds new tests -->
- [ ] Chore
<!--
updates the way this repository is run
- ci
- issue templates
- license
- deployment
- release
-->
