### PR TITLE
enhance(gotest): in-loop unnamed subcase name with out of loop struct

### DIFF
--- a/lib/framework/golang/gotest.rs
+++ b/lib/framework/golang/gotest.rs
@@ -180,6 +180,8 @@ pub(in crate::framework::golang) mod golang_subtests {
             get_string_literal_subtests,
             get_in_loop_with_named_subtests,
             get_in_loop_with_unnamed_subtests,
+            get_in_loop_typed_subcase_with_unnamed_case_fields,
+            get_in_loop_typed_subcase_with_named_case_fields,
         ];
         for func in finders {
             if let Some(t) = func(
@@ -535,7 +537,7 @@ pub(in crate::framework::golang) mod golang_subtests {
     // 		})
     // 	}
     // }
-    fn get_in_loop_typed_testcase_with_unnamed_case_fields(
+    fn get_in_loop_typed_subcase_with_unnamed_case_fields(
         node: Node,
         content: &str,
         parent: Runnable,
@@ -631,7 +633,12 @@ pub(in crate::framework::golang) mod golang_subtests {
     // 		})
     // 	}
     // }
-    fn get_in_loop_typed_testcase_with_named_case_fields() -> Option<Vec<Runnable>> {
+    fn get_in_loop_typed_subcase_with_named_case_fields(
+        node: Node,
+        content: &str,
+        parent: Runnable,
+        current_position: Option<CursorPosition>,
+    ) -> Option<Vec<Runnable>> {
         const QUERY_PATTERN: &str = r#"
 		        [[
               ;; query for function name
@@ -705,7 +712,7 @@ pub(in crate::framework::golang) mod golang_subtests {
                 )
               ))
             ]]"#;
-        todo!()
+        subtest_loop_find_helper(node, content, QUERY_PATTERN, parent, current_position)
     }
 
     // get_out_loop_named_tabletests

--- a/lib/framework/golang/gotest_test.rs
+++ b/lib/framework/golang/gotest_test.rs
@@ -331,12 +331,12 @@ mod test {
 
     #[gtest]
     #[rstest]
-    #[case(enums::Search::InFile, types::CursorPosition::new(19, 3), 2, vec!["TestInLoopWithNamedSubtest/base case", "TestInLoopWithNamedSubtest/case 1"])]
-    #[case(enums::Search::Nearest, types::CursorPosition::new(20, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
-    #[case(enums::Search::Nearest, types::CursorPosition::new(21, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
-    #[case(enums::Search::Nearest, types::CursorPosition::new(25, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
-    #[case(enums::Search::Nearest, types::CursorPosition::new(26, 3), 1, vec!["TestInLoopWithNamedSubtest/case 1"])]
-    #[case(enums::Search::Nearest, types::CursorPosition::new(31, 3), 1, vec!["TestInLoopWithNamedSubtest/case 1"])]
+    #[case(enums::Search::InFile, types::CursorPosition::new(19, 3), 2, vec!["TestGetInLoopTypedSubcaseWithUnnamedCaseFields/base case", "TestGetInLoopTypedSubcaseWithUnnamedCaseFields/case 1"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(20, 3), 1, vec!["TestGetInLoopTypedSubcaseWithUnnamedCaseFields/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(21, 3), 1, vec!["TestGetInLoopTypedSubcaseWithUnnamedCaseFields/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(25, 3), 1, vec!["TestGetInLoopTypedSubcaseWithUnnamedCaseFields/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(26, 3), 1, vec!["TestGetInLoopTypedSubcaseWithUnnamedCaseFields/case 1"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(31, 3), 1, vec!["TestGetInLoopTypedSubcaseWithUnnamedCaseFields/case 1"])]
     fn get_in_loop_typed_subcase_with_unnamed_case_fields(
         #[case] search: enums::Search,
         #[case] position: types::CursorPosition,

--- a/lib/framework/golang/gotest_test.rs
+++ b/lib/framework/golang/gotest_test.rs
@@ -328,4 +328,95 @@ mod test {
             assert_that!(runnable.is_some(), eq(true));
         }
     }
+
+    #[gtest]
+    #[rstest]
+    #[case(enums::Search::InFile, types::CursorPosition::new(19, 3), 2, vec!["TestInLoopWithNamedSubtest/base case", "TestInLoopWithNamedSubtest/case 1"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(20, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(21, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(25, 3), 1, vec!["TestInLoopWithNamedSubtest/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(26, 3), 1, vec!["TestInLoopWithNamedSubtest/case 1"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(31, 3), 1, vec!["TestInLoopWithNamedSubtest/case 1"])]
+    fn get_in_loop_typed_subcase_with_unnamed_case_fields(
+        #[case] search: enums::Search,
+        #[case] position: types::CursorPosition,
+        #[case] expected_num_of_tests: usize,
+        #[case] expected_test_names: Vec<&str>,
+    ) {
+        // ARRANGE
+        let content = r#"
+        package golang
+        import (
+          "testing"
+
+          "github.com/stretchr/testify/assert"
+        )
+
+        func sample_add(a, b int) int {
+          return a + b
+        }
+
+        func TestGetInLoopTypedSubcaseWithUnnamedCaseFields(t *testing.T) {
+          type Scenario struct {
+            description string
+            a           int
+            b           int
+            expected    int
+          }
+          for _, tt := range []Scenario{
+            {
+              "base case",
+              0,
+              3,
+              3,
+            },
+            {
+              "case 1",
+              1,
+              3,
+              4,
+            },
+          } {
+            t.Run(tt.description, func(t *testing.T) {
+              actual := sample_add(tt.a, tt.b)
+              assert.Equal(t, tt.expected, actual)
+            })
+          }
+        }
+        "#;
+
+        let buffer = Buffer::new(content, "run_test.go".to_string(), position);
+        let mut target = Target::new(enums::ToolCategory::TestRunner, buffer);
+        target.override_search_strategy(search);
+
+        let tree = common::utils::parse_tree(content);
+        assert_that!(tree, ok(anything()));
+        let tree = tree.unwrap();
+        let mut walker = tree.walk();
+
+        walker.goto_first_child_for_point(position.to_point());
+
+        let node = walker.node();
+        let parent_runnable = get_parent_test(Some(node), &target);
+        assert_that!(parent_runnable.is_some(), eq(true));
+        let parent_runnable = parent_runnable.unwrap();
+        assert_eq!(
+            parent_runnable.name,
+            "TestGetInLoopTypedSubcaseWithUnnamedCaseFields"
+        );
+
+        walker.reset(node);
+
+        // ACT
+        let res = get_sub_tests(Some(node), Some(parent_runnable), &target);
+
+        // ASSERT
+        assert_that!(res.is_some(), eq(true));
+        let res = res.unwrap();
+        assert_that!(res.len(), eq(expected_num_of_tests));
+        for ts in expected_test_names {
+            let runnable = res.iter().find(|&x| x.name == ts);
+            assert_that!(runnable.is_some(), eq(true));
+        }
+    }
 }


### PR DESCRIPTION
## Related Issue  
<!-- Attached the related issue -->
N/A
### Additional Context

<!-- (Optional) add additional context about pull-request about. -->

```go
func TestGetInLoopTypedSubcaseWithUnnamedCaseFields(t *testing.T) {
  type Scenario struct {
        description string
        a           int
        b           int
        expected    int
  }
  for _, tt := range []Scenario{
          {
                "base case",
                0,
                3,
                3,
          },
          {
                "case 1",
                1,
                3,
                4,
          },
  } {
    t.Run(tt.description, func(t *testing.T) {
      actual := sample_add(tt.a, tt.b)
      assert.Equal(t, tt.expected, actual)
    })
  }
}

```

### How is it implemented



<!-- How is this change implemented -->

### Check the related fields

- [ ] Documentation <!-- Updates the documentation and related to this repository -->
- [ ] Feature <!-- Adds a net new capability -->
- [x] Enhancement <!-- updates an existing feature and adds to it -->
- [x] Test <!-- updates or adds new tests -->
- [ ] Chore
<!--
updates the way this repository is run
- ci
- issue templates
- license
- deployment
- release
-->
