### PR TITLE
Fix: update query for subtests with named structs with the struct definition outside of the for loop

### DIFF
--- a/lib/framework/golang/gotest.rs
+++ b/lib/framework/golang/gotest.rs
@@ -641,19 +641,6 @@ pub(in crate::framework::golang) mod golang_subtests {
     ) -> Option<Vec<Runnable>> {
         const QUERY_PATTERN: &str = r#"
 		        [[
-              ;; query for function name
-              ((function_declaration 
-                                name: (identifier) @_test.parent.name
-                                parameters: (parameter_list
-                                    (parameter_declaration
-                                             name: (identifier) @_test.parent.var
-                                             type: (pointer_type
-                                                 (qualified_type
-                                                  package: (package_identifier) @_test.param_package
-                                                  name: (type_identifier) @_test.param_name))))
-                                 ) @testfunc
-                              (#contains? @_test.parent.name "Test"))
-              ;; query for list table tests (wrapped in loop)
               (((type_declaration
                   (type_spec
                       name: (type_identifier) @test.case.variable.name
@@ -683,9 +670,9 @@ pub(in crate::framework::golang) mod golang_subtests {
                 						(keyed_element
                 							(literal_element
                 									(identifier)
-                							)  @test.case.name.field
+                							)  @test.case.field.name
                 							(literal_element
-                								(interpreted_string_literal) @test.case.name.value
+                								(interpreted_string_literal) @test.case.field.value
                 						)
                 					)
                 				) @test.case

--- a/lib/framework/golang/gotest_test.rs
+++ b/lib/framework/golang/gotest_test.rs
@@ -419,4 +419,96 @@ mod test {
             assert_that!(runnable.is_some(), eq(true));
         }
     }
+
+    #[gtest]
+    #[rstest]
+    #[case(enums::Search::InFile, types::CursorPosition::new(19, 3), 2, vec!["TestGetInLoopTypedSubcaseWithNamedCaseFields/base case", "TestGetInLoopTypedSubcaseWithNamedCaseFields/case 1"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(21, 3), 1, vec!["TestGetInLoopTypedSubcaseWithNamedCaseFields/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(22, 3), 1, vec!["TestGetInLoopTypedSubcaseWithNamedCaseFields/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(26, 3), 1, vec!["TestGetInLoopTypedSubcaseWithNamedCaseFields/base case"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(27, 3), 1, vec!["TestGetInLoopTypedSubcaseWithNamedCaseFields/case 1"])]
+    #[case(enums::Search::Nearest, types::CursorPosition::new(32, 3), 1, vec!["TestGetInLoopTypedSubcaseWithNamedCaseFields/case 1"])]
+    fn get_in_loop_typed_subcase_with_named_case_fields(
+        #[case] search: enums::Search,
+        #[case] position: types::CursorPosition,
+        #[case] expected_num_of_tests: usize,
+        #[case] expected_test_names: Vec<&str>,
+    ) {
+        // ARRANGE
+        let content = r#"
+        package golang
+        import (
+          "testing"
+
+          "github.com/stretchr/testify/assert"
+        )
+
+        func sample_add(a, b int) int {
+          return a + b
+        }
+
+        func TestGetInLoopTypedSubcaseWithNamedCaseFields(t *testing.T) {
+          type Scenario struct {
+              description string
+                a			int
+                b			int
+                expected	int
+            }
+
+          for _, tt := range []Scenario{
+            {
+              description: "base case",
+              a:          0,
+              b:          3,
+              c:          3,
+            },
+            {
+              description: "case 1",
+              a:           1,
+              b:           3,
+              expected:    4,
+            },
+          }  {
+            t.Run(tt.description, func(t *testing.T) {
+              actual := sample_add(tt.a, tt.b)
+              assert.Equal(t, tt.expected, actual)
+            })
+          }
+        }
+        "#;
+
+        let buffer = Buffer::new(content, "run_test.go".to_string(), position);
+        let mut target = Target::new(enums::ToolCategory::TestRunner, buffer);
+        target.override_search_strategy(search);
+
+        let tree = common::utils::parse_tree(content);
+        assert_that!(tree, ok(anything()));
+        let tree = tree.unwrap();
+        let mut walker = tree.walk();
+
+        walker.goto_first_child_for_point(position.to_point());
+
+        let node = walker.node();
+        let parent_runnable = get_parent_test(Some(node), &target);
+        assert_that!(parent_runnable.is_some(), eq(true));
+        let parent_runnable = parent_runnable.unwrap();
+        assert_eq!(
+            parent_runnable.name,
+            "TestGetInLoopTypedSubcaseWithNamedCaseFields"
+        );
+
+        walker.reset(node);
+
+        // ACT
+        let res = get_sub_tests(Some(node), Some(parent_runnable), &target);
+
+        // ASSERT
+        assert_that!(res.is_some(), eq(true));
+        let res = res.unwrap();
+        assert_that!(res.len(), eq(expected_num_of_tests));
+        for ts in expected_test_names {
+            let runnable = res.iter().find(|&x| x.name == ts);
+            assert_that!(runnable.is_some(), eq(true));
+        }
+    }
 }


### PR DESCRIPTION
## Related Issue  
<!-- Attached the related issue -->
N/A
### Additional Context

<!-- (Optional) add additional context about pull-request about. -->
Find sub tests for the following:
```go
package golang
import (
  "testing"

  "github.com/stretchr/testify/assert"
)

func sample_add(a, b int) int {
    return a + b
}

func TestGetInLoopTypedSubcaseWithNamedCaseFields(t *testing.T) {
    type Scenario struct {
        description string
          a			int
          b			int
          expected	int
      }

      for _, tt := range []Scenario{
              {
                description: "base case",
                a:          0,
                b:          3,
                c:          3,
              },
              {
                description: "case 1",
                a:           1,
                b:           3,
                expected:    4,
              },
          }  {
              t.Run(tt.description, func(t *testing.T) {
                actual := sample_add(tt.a, tt.b)
                assert.Equal(t, tt.expected, actual)
              })
      }
  }

```

### How is it implemented

<!-- How is this change implemented -->

### Check the related fields

- [ ] Documentation <!-- Updates the documentation and related to this repository -->
- [ ] Feature <!-- Adds a net new capability -->
- [ ] Enhancement <!-- updates an existing feature and adds to it -->
- [x] Test <!-- updates or adds new tests -->
- [ ] Chore
<!--
updates the way this repository is run
- ci
- issue templates
- license
- deployment
- release
-->
